### PR TITLE
Add initial draft of existing practice section

### DIFF
--- a/D2892R0.md
+++ b/D2892R0.md
@@ -5,7 +5,7 @@ date: 2023-05-16
 audience: Library Evolution
 author:
   - name: Joe Jevnik
-    email: <joe@quantopian.com>
+    email: <joejev@gmail.com>
   - name: David Sankel
     email: <dsankel@adobe.com>
 toc: false
@@ -41,8 +41,6 @@ Set context:
 - Point out benefits of value semantics for std::simd types
 - Point out status quo that we are trying to change
 
-[@P1371] is an example citation. We'll need to cite the SIMD paper
-
 # Value semantics and its advantages
 
 - Introduce value semantics
@@ -56,54 +54,64 @@ Set context:
 
 # Existing practice
 
-- Show table of what's there.
-- Provide argument how coherence of the standard library should weigh strongly
-  here where it might not in some of these other contexts.
+There exists many libraries which wrap SIMD operations today.
+Some libraries more explicitly wrap a single SIMD register, like VCL or xsimd,  where others express larger arrays or mathematical objects.
+The following table covers some open source libraries and their choices with respect to comparison operators.
+
+| Library                            | Comparison Behavior                                              |
+| ---------------------------------- | ---------------------------------------------------------------- |
+| Armadillo                          | Element-wise                                                     |
+| Blaze                              | Regular                                                          |
+| EVE                                | Element-wise                                                     |
+| Eigen::Array                       | Element-wise                                                     |
+| Eigen::{Matrix, RowVector, Vector} | Regular                                                          |
+| Fastor                             | Element-wise                                                     |
+| VCL                                | Element-wise                                                     |
+| xsimd                              | Element-wise                                                     |
+| xtensor                            | Regular `operator==` and `operator!=`; rest are element-wise[^1] |
+
+## Wrappers and DSLs
+
+These libraries exist broadly in two categories: wrappers around SIMD operations and DSLs (domain specific languages) for doing math and multidimensional array operations.
+For libraries that are conceptually DSLs: users are unlikely to switch away from these high level tools.
+If end users want to use a DSL, they will be shielded from the particular syntactic choices used by `std::simd` and this is an irrelevant decision for them.
+
+For users who want to introduce a small amount of data parallelism in their code, or are implementers of a DSL, having regular comparison will fit more naturally into rest of the C++ language for the reasons stated above.
+Non-DSL users will still see a considerable benefit with respect to conciseness and clarity over using platform specific intrinsic operations, even with value-semantics.
+For example if we compare one of the algorithms in [@P1928R3] which used element-wise `operator>=`, the new proposal is not considerably more verbose nor unclear:
+
+```diff
+ using floatv = std::simd<float>
+ using intv = std::rebind_simd_t<int, floatv>;
+
+ int count_positive(const std::vector<floatv>& xs) {
+     // simplify generated assembly:
+     if (x.size() == 0) std::unreachable();
+     intv counter = {};
+     for (std::simd x : xs) {
+-        counter += x > 0;
++        counter += @_greater_@(x, 0);
+     }
+     return reduce(counter);
+ }
+```
 
 # Conclusion
 
 Stuffies...
 
+[^1]: This option is only used in xtensor, not even the related project xsimd.
+      The inconsistency seems more likely to cause bugs than selecting either behavior by itself.
+
 ---
 references:
-  - id: P1371
-    citation-label: P1371
-    title: "Pattern Matching"
+  - id: P1928R3
+    citation-label: P1928R3
+    title: "Merge Data-Parallel Types From the Parallelism TS 2"
     author:
-      - family: Murzin
-        given: Sergei
-      - family: Park
-        given: Michael
-      - family: Sankel
-        given: David
-      - family: Sarginson
-        given: Dan
+      - family: Kretz
+        given: Matthias
     issued:
-      year: 2019
-    url: http://wg21.link/P1371
-  - id: RefImpl
-    citation-label: RefImpl
-    title: "Exhaustiveness Checking Reference Implementation"
-    author:
-      - family: Sankel
-        given: David
-    URL: https://github.com/camio/exhaustiveness_checking
-  - id: maranget_2007
-    type: article-journal
-    issued:
-      year: 2007
-    volume: 17
-    publisher: "Cambridge University Press"
-    page: "387-421"
-    container-title: "Journal of Functional Programming"
-    citation-label: maranget_2007
-    title: "Warnings for pattern matching"
-    author:
-      - family: Maranget
-        given: Luc
-    URL: https://github.com/camio/exhaustiveness_checking
-  - id: RustLang
-    citation-label: RustLang
-    title: "Rust Website"
-    URL: https://www.rust-lang.org/
+      year: 2023
+    url: http://wg21.link/P1928R3
 ---


### PR DESCRIPTION
Adds the table presented at C++Now with the following modifications:
- adds Armadillo, another popular linear algebra library
- adds xtensor, a project which is related to xsimd but for arbitrarily sized multidimensional arrays
- removes the Python library examples

Adds a brief section on the difference between a SIMD wrapper and a DSL, as I see it.

Adds a diff to compare an example presented in P1928R3 with the new code.

This draft does not introduce a name for the new element-wise comparison functions. This should be addressed before submission.

I believe I need to elaborate more on why we are going against the overwhelming majority of existing practice. The short reason is something like: "these libraries are either DSLs, or implemented for people who are used to using a DSL and not for seamless interoperability with the rest of the C++ standard library or language".