### PR TITLE
add defaulted operator example and C++ now poll results

### DIFF
--- a/D2892R0.md
+++ b/D2892R0.md
@@ -69,15 +69,58 @@ void f() {
 Set context:
 
 - std::simd being proposed for standardization
-- Discussions at C++Now conference. Point out the poll numbers
 - Point out benefits of value semantics for std::simd types
 - Point out status quo that we are trying to change
+
+## C++Now discussion
+
+At the C++Now conference held from May 9th through May 12th, `std::simd` was discussed during the library in a week session.
+During this discussion, there were originally arguments both in favor of element-wise comparison and value-semantics.
+The C++Now discussion led us to collect the existing practice table and present pros and cons to each approach.
+Once all of the arguments were presented, we took the straw poll: "std::simd operator== return a scalar bool"
+
+|SF| F| N| A|SA|
+|--|--|--|--|--|
+| 9|10| 0| 1| 0|
 
 # Value semantics and its advantages
 
 - Introduce value semantics
 - Discuss C++ rendering
 - Discuss advantages of uniform treatment
+
+## Integration with defaulted `operator==` and `operator<=>`
+
+Imagine a user has written the following classes and would like to accelerate them using `std::simd`:
+
+```c++
+struct Pixel {
+    std::uint32_t red = 0;
+    std::uint32_t green= 0;
+    std::uint32_t blue = 0;
+    std::uint32_t alpha = 0;
+
+    bool operator==(const Pixel&) const = default;
+};
+```
+
+Here, a user might try to write something like:
+
+```c++
+struct Pixel {
+    std::simd<std::uint32_t> value{};
+
+    std::uint32_t red() const;
+    std::uint32_t green() const;
+    std::uint32_t blue() const;
+    std::uint32_t alpha() const;
+
+    bool operator==(const Pixel&) const = default;  // error, cannot provide default
+};
+```
+
+Making comparisons element-wise will undo the benefits of introducing defaulted `operator==` and `operator<=>` to the language and force users to write trivial implementations of these functions for every structure that embeds a `std::simd`.
+
 
 # std::simd types and value semantics
 


### PR DESCRIPTION
I think the poll results are rendering poorly because the titles are center aligned and the contents are left aligned, is this a setting we can tweak in the generator?

I would also like that setting for the comparison table.